### PR TITLE
Sea monkey fixes

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -1,5 +1,6 @@
 content	tiddlyfox	content/
 overlay	chrome://browser/content/browser.xul	chrome://tiddlyfox/content/overlay.xul
+overlay chrome://navigator/content/navigator.xul  chrome://tiddlyfox/content/overlay.xul
 
 locale	tiddlyfox	en-US	locale/en-US/
 

--- a/content/overlay.xul
+++ b/content/overlay.xul
@@ -9,4 +9,9 @@
     <menuitem id="tiddlyfox-hello" label="&tiddlyfox;" 
               oncommand="TiddlyFox.onMenuItemCommand(event);"/>
   </menupopup>
+  <!-- for SeaMonkey -->
+  <menupopup id="taskPopup">
+    <menuitem id="tiddlyfox-hello" label="&tiddlyfox;" 
+              oncommand="TiddlyFox.onMenuItemCommand(event);"/>
+  </menupopup>
 </overlay>

--- a/install.rdf
+++ b/install.rdf
@@ -31,7 +31,15 @@
             <em:maxVersion>15.*</em:maxVersion>
         </Description>
     </em:targetApplication>
-
+    <!-- SeaMonkey -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
+        <em:minVersion>2.0</em:minVersion>
+        <em:maxVersion>2.27.*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    
   </Description>
 
 </RDF>


### PR DESCRIPTION
These changes are enough to make TiddlyFox work in SeaMonkey 22.0 (issue #13), all based on https://developer.mozilla.org/en-US/docs/Extensions_support_in_SeaMonkey_2

Thanks for this extension!
