### PR TITLE
typo bugfix: method 'text' is undefined

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -135,7 +135,7 @@ var TiddlyFox = {
 		var versionArea = doc.getElementById("versionArea");
 		return (doc.location.protocol === "file:") &&
 			doc.getElementById("storeArea") &&
-			(versionArea && /TiddlyWiki/.test(versionArea.text));
+			(versionArea && /TiddlyWiki/.test(versionArea.textContent));
 	},
 
 	isTiddlyWiki5: function(doc,win) {


### PR DESCRIPTION
Method 'text' not worked for me (using a custom DIDO/TiddlyWiki/Exhibit application).
