### PR TITLE
rapped code in a closure to hide globally exposed function

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -3,7 +3,7 @@
 The JavaScript code in this file is executed via `overlay.xul` when Firefox starts up.
 
 */
-
+var TiddlyFox = (function () {
 var TiddlyFox = {
 
 	// Name of the permission for TiddlyFox used by Firefox
@@ -179,3 +179,5 @@ window.addEventListener("load",function load(event) {
 	window.removeEventListener("load",load,false);
 	TiddlyFox.onLoad(event);
 },false); 
+return TiddlyFox;
+}());


### PR DESCRIPTION
On the error console there was a failure shown in makeURI(), which was in the global scope. - so much for the mozilla addon review process! 
can now use Smart Keyword 
I have only tested this change on  version 25 on ubuntu 12.04. 
